### PR TITLE
Refactor git module to use configurable options for user details

### DIFF
--- a/modules/home-manager/git/default.nix
+++ b/modules/home-manager/git/default.nix
@@ -1,102 +1,117 @@
 { self, inputs, ... }:
 {
   flake.homeModules.git =
-    { pkgs, lib, ... }:
+    { pkgs, lib, config, ... }:
     {
-      programs.gh.enable = true;
-
-      programs.git = {
-        enable = true;
-        lfs.enable = true;
-
-        signing = {
-          key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBDohImxI6S0ieD8jmleD3IUj8ZrKFaAVbLBhGab7luu";
-          signByDefault = true;
-          format = "openpgp";
+      options.git = {
+        userName = lib.mkOption {
+          type = lib.types.str;
+          default = "thebromo";
+          description = "Git user name";
         };
+        userEmail = lib.mkOption {
+          type = lib.types.str;
+          default = "manuel@strenge.ch";
+          description = "Git user email";
+        };
+      };
 
-        settings = {
-          user = {
-            Name = "thebromo";
-            Email = "manuel@strenge.ch";
-          };
-          init.defaultBranch = "main";
-          pull.rebase = "true";
-          delta.enable = "true";
-          column.ui = "auto";
-          branch.sort = "-committerdate";
-          tag.sort = "version:refname";
-          diff = {
-            algorithm = "histogram";
-            colorMoved = "plain";
-            mnemonicPrefix = true;
-            renames = true;
-          };
-          push = {
-            default = "simple";
-            autoSetupRemote = true;
-            followTags = true;
-          };
-          fetch = {
-            prune = true;
-            pruneTags = true;
-            all = true;
-          };
-          help.autocorrect = "prompt";
-          commit.verbose = true;
-          rerere = {
-            enabled = true;
-            autoupdate = true;
-          };
-          core = {
-            excludesfile = "~/.gitignore";
-            fsmonitor = true;
-            untrackedCache = true;
-          };
-          rebase = {
-            autoSquash = true;
-            autoStash = true;
-            updateRefs = true;
-          };
-          merge = {
-            conflictstyle = "zdiff3";
+      config = {
+        programs.gh.enable = true;
+
+        programs.git = {
+          enable = true;
+          lfs.enable = true;
+
+          signing = {
+            key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBDohImxI6S0ieD8jmleD3IUj8ZrKFaAVbLBhGab7luu";
+            signByDefault = true;
+            format = "openpgp";
           };
 
-          gpg = {
-            format = "ssh";
-            ssh = {
-              program =
-                if pkgs.stdenv.isDarwin then
-                  "/Applications/1Password.app/Contents/MacOS/op-ssh-sign"
-                else
-                  lib.getExe' pkgs._1password-gui "op-ssh-sign";
-              allowedSignersFile =
-                let
-                  allowedSigners = pkgs.writeText "git-ssh-allowed-signers" ''
-                    manuel@strenge.ch ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBDohImxI6S0ieD8jmleD3IUj8ZrKFaAVbLBhGab7luu
-                    manuel.strenge-ext@hexagon.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBDohImxI6S0ieD8jmleD3IUj8ZrKFaAVbLBhGab7luu
-                  '';
-                in
-                "${allowedSigners}";
+          settings = {
+            user = {
+              Name = config.git.userName;
+              Email = config.git.userEmail;
             };
+            init.defaultBranch = "main";
+            pull.rebase = "true";
+            delta.enable = "true";
+            column.ui = "auto";
+            branch.sort = "-committerdate";
+            tag.sort = "version:refname";
+            diff = {
+              algorithm = "histogram";
+              colorMoved = "plain";
+              mnemonicPrefix = true;
+              renames = true;
+            };
+            push = {
+              default = "simple";
+              autoSetupRemote = true;
+              followTags = true;
+            };
+            fetch = {
+              prune = true;
+              pruneTags = true;
+              all = true;
+            };
+            help.autocorrect = "prompt";
+            commit.verbose = true;
+            rerere = {
+              enabled = true;
+              autoupdate = true;
+            };
+            core = {
+              excludesfile = "~/.gitignore";
+              fsmonitor = true;
+              untrackedCache = true;
+            };
+            rebase = {
+              autoSquash = true;
+              autoStash = true;
+              updateRefs = true;
+            };
+            merge = {
+              conflictstyle = "zdiff3";
+            };
+
+            gpg = {
+              format = "ssh";
+              ssh = {
+                program =
+                  if pkgs.stdenv.isDarwin then
+                    "/Applications/1Password.app/Contents/MacOS/op-ssh-sign"
+                  else
+                    lib.getExe' pkgs._1password-gui "op-ssh-sign";
+                allowedSignersFile =
+                  let
+                    allowedSigners = pkgs.writeText "git-ssh-allowed-signers" ''
+                      manuel@strenge.ch ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBDohImxI6S0ieD8jmleD3IUj8ZrKFaAVbLBhGab7luu
+                      manuel.strenge-ext@hexagon.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBDohImxI6S0ieD8jmleD3IUj8ZrKFaAVbLBhGab7luu
+                    '';
+                  in
+                  "${allowedSigners}";
+              };
+            };
+            credential."https://github.zhaw.ch".helper = "${lib.getExe pkgs.gh} auth git-credential";
+            credential."https://gitlab.com/".helper =
+              "!f() { test \"$1\" = get && echo \"password=$(op read \"$PARAGON_GITLAB_USER_PAT_OP\")\"; }; f";
           };
-          credential."https://github.zhaw.ch".helper = "${lib.getExe pkgs.gh} auth git-credential";
-          credential."https://gitlab.com/".helper =
-            "!f() { test \"$1\" = get && echo \"password=$(op read \"$PARAGON_GITLAB_USER_PAT_OP\")\"; }; f";
         };
-      };
 
-      programs.gpg = {
-        enable = true;
-        package = pkgs.gnupg;
-      };
+        programs.gpg = {
+          enable = true;
+          package = pkgs.gnupg;
+        };
 
-      programs.lazygit = {
-        enable = true;
-        settings = {
-          overrideGpg = true;
-          gui.border = "single";
-          os.editPreset = "nvim";
+        programs.lazygit = {
+          enable = true;
+          settings = {
+            overrideGpg = true;
+            gui.border = "single";
+            os.editPreset = "nvim";
+          };
         };
       };
     };

--- a/modules/home-manager/git/default.nix
+++ b/modules/home-manager/git/default.nix
@@ -1,7 +1,12 @@
 { self, inputs, ... }:
 {
   flake.homeModules.git =
-    { pkgs, lib, config, ... }:
+    {
+      pkgs,
+      lib,
+      config,
+      ...
+    }:
     {
       options.git = {
         userName = lib.mkOption {

--- a/modules/home-manager/git/hexagon/default.nix
+++ b/modules/home-manager/git/hexagon/default.nix
@@ -1,13 +1,9 @@
 { self, inputs, ... }:
 {
   flake.homeModules.gitHexagon =
-    { lib, ... }:
+    { ... }:
     {
-      programs.git.settings = {
-        user = {
-          Name = lib.mkForce "Manuel Strenge";
-          Email = lib.mkForce "manuel.strenge-ext@hexagon.com";
-        };
-      };
+      git.userName = "Manuel Strenge";
+      git.userEmail = "manuel.strenge-ext@hexagon.com";
     };
 }

--- a/modules/hosts/manuel-darwin/configuration.nix
+++ b/modules/hosts/manuel-darwin/configuration.nix
@@ -15,7 +15,6 @@
         self.homeModules.wsswitch
         self.homeModules.tmux
         self.homeModules.nvimConfig
-        self.homeModules.gitHexagon
       ];
 
       home = {

--- a/modules/hosts/manuel-darwin/configuration.nix
+++ b/modules/hosts/manuel-darwin/configuration.nix
@@ -15,6 +15,7 @@
         self.homeModules.wsswitch
         self.homeModules.tmux
         self.homeModules.nvimConfig
+        self.homeModules.gitHexagon
       ];
 
       home = {


### PR DESCRIPTION
## Summary
Refactored the git home-manager module to make user name and email configurable through module options rather than hardcoded values. This enables better composability and allows different configurations to override these settings cleanly.

## Key Changes
- Added `options.git` with `userName` and `userEmail` options to the main git module with sensible defaults
- Moved all git configuration into a `config` block to properly separate option definitions from implementation
- Updated git settings to reference `config.git.userName` and `config.git.userEmail` instead of hardcoded values
- Simplified the `gitHexagon` module to set git options directly instead of using `lib.mkForce` to override nested settings
- Removed unnecessary `lib` parameter from `gitHexagon` module since it no longer needs it

## Implementation Details
This change follows NixOS module system best practices by:
- Defining explicit options that can be overridden by other modules
- Using the standard `options`/`config` separation pattern
- Allowing the `gitHexagon` module to simply set `git.userName` and `git.userEmail` at the top level, which is cleaner and more maintainable than forcing overrides deep in the settings tree

https://claude.ai/code/session_016j1qcvtajiiC6d8CjDDv6i